### PR TITLE
kickstart nuxt CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,12 +3,10 @@ name: ci
 on:
   push:
     branches:
-      - main
-      - master
+      - gh-pages
   pull_request:
     branches:
-      - main
-      - master
+      - gh-pages
 
 jobs:
   ci:


### PR DESCRIPTION
changed branch name in workflow file so that deployments happen off of `gh-pages` branch instead of master. hoping this triggers a workflow run...